### PR TITLE
externalize secrets and add security settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Django Settings
+# Generate a new SECRET_KEY with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+DJANGO_SECRET_KEY='your-secret-key-here'
+
+# Set to True for local development, False for production
+DEBUG=True
+
+# Comma-separated list of allowed hosts
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# Database URL (optional, defaults to SQLite)
+# For PostgreSQL: postgres://user:password@localhost:5432/dbname
+# DATABASE_URL=sqlite:///db.sqlite3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Notes
+
+## SECRET_KEY Rotation
+
+**Date:** March 3, 2026  
+**Action:** Rotated Django SECRET_KEY
+
+### Background
+The original SECRET_KEY was hardcoded in `settings.py` and committed to Git history. This key is now considered compromised and has been rotated.
+
+### What Was Done
+1. Generated a new SECRET_KEY using Django's `get_random_secret_key()` utility
+2. Moved SECRET_KEY to environment variables (`.env` file)
+3. Updated `settings.py` to read SECRET_KEY from environment
+4. Added `.env` to `.gitignore` to prevent future commits
+
+### Important
+**DO NOT reuse the old SECRET_KEY** (`django-insecure-xa$j-a+m%r@-x(kvs*rtgs_7qq8ofdhpsqe5+rv-2wd=8lai-t`).
+
+This key was exposed in Git history and should be considered public. Any production deployments must use a new, securely generated key.
+
+### Generating a New SECRET_KEY
+To generate a new SECRET_KEY for production:
+
+```bash
+python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+```
+
+Store the generated key in your production environment's secrets manager (AWS Secrets Manager, environment variables, etc.).
+
+## Security Best Practices
+
+### Environment Variables
+- Never commit `.env` files to version control
+- Use different SECRET_KEYs for development, staging, and production
+- Rotate secrets regularly (at least annually, or immediately if compromised)
+
+### Production Deployment
+- Always set `DEBUG=False` in production
+- Use HTTPS (enforced via `SECURE_SSL_REDIRECT=True`)
+- Configure `ALLOWED_HOSTS` to only include your actual domains
+- Use a secrets manager (AWS Secrets Manager, HashiCorp Vault, etc.)
+
+### Reporting Security Issues
+If you discover a security vulnerability, please email [your-email@example.com] instead of opening a public issue.

--- a/learning_log/settings.py
+++ b/learning_log/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 import os
+from decouple import config, Csv
 import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -22,12 +23,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-xa$j-a+m%r@-x(kvs*rtgs_7qq8ofdhpsqe5+rv-2wd=8lai-t'
+SECRET_KEY = config('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=False, cast=bool)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv())
 
 
 # Application definition
@@ -140,12 +141,27 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # My settings 
 LOGIN_URL = 'users:login'
 
-# Heroku settings
+# Security settings for production
+if not DEBUG:
+    # HTTPS settings
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    
+    # HSTS (HTTP Strict Transport Security)
+    SECURE_HSTS_SECONDS = 31536000  # 1 year
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    
+    # Security headers
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_REFERRER_POLICY = 'same-origin'
+    X_FRAME_OPTIONS = 'DENY'
+    
+    # Proxy awareness for AWS ALB
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    
+    # CSRF trusted origins (update with your domain)
+    CSRF_TRUSTED_ORIGINS = config('CSRF_TRUSTED_ORIGINS', default='', cast=Csv())
 
-import django_heroku
-django_heroku.settings(locals())
 
-if os.environ.get('DEBUG') == 'TRUE':
-    DEBUG = True
-elif os.environ.get('DEBUG') == 'FALSE':
-    DEBUG = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,10 @@ beautifulsoup4==4.12.2
 dj-database-url==2.1.0
 Django==4.2.5
 django-bootstrap4==23.2
-django-heroku==0.3.1
 gunicorn==21.2.0
 packaging==23.1
 psycopg2==2.9.7
-psycopg2-binary==2.9.7
+python-decouple==3.8
 soupsieve==2.5
 sqlparse==0.4.4
 typing_extensions==4.8.0


### PR DESCRIPTION
##  Externalize Secrets and Add Security Settings

### Stories Completed
- **Story 2.1:** Move secrets to environment variables
- **Story 2.2:** Add HTTPS enforcement and security headers

### Problem
- Hardcoded secrets 
- No environment-specific configuration (dev/staging/prod used same settings)
- Missing production security headers (HTTPS, HSTS, etc.)
- Using deprecated `django-heroku` package

### Solution

#### Secrets Management
- Installed `python-decouple` for environment variable management
- Created `.env` file for local secrets (gitignored)
- Created `.env.example` as template
- Generated new SECRET_KEY
- Updated `settings.py` to read from environment variables

#### Production Security
Added security settings that activate when `DEBUG=False`:
- `SECURE_SSL_REDIRECT = True` - Force HTTPS
- `SESSION_COOKIE_SECURE = True` - Secure cookies
- `CSRF_COOKIE_SECURE = True` - Secure CSRF tokens
- `SECURE_HSTS_SECONDS = 31536000` - HSTS for 1 year
- `X_FRAME_OPTIONS = 'DENY'` - Prevent clickjacking
- `SECURE_CONTENT_TYPE_NOSNIFF = True` - Prevent MIME sniffing
- `SECURE_PROXY_SSL_HEADER` - AWS ALB proxy awareness

#### Cleanup
- Removed deprecated `django-heroku` package
- Removed duplicate `psycopg2-binary` dependency
- Documented key rotation in `SECURITY.md`